### PR TITLE
[FIX] adapt the account.move creation from account.payment following the odoo refactor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,8 +47,6 @@ repos:
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
-      - id: oca-fix-manifest-website
-        args: ["https://github.com/OCA/purchase-workflow"]
       - id: oca-gen-addon-readme
         args:
           - --addons-dir=.

--- a/account_factoring/__manifest__.py
+++ b/account_factoring/__manifest__.py
@@ -5,14 +5,11 @@
     "name": "Account Factoring",
     "summary": """
         Factoring""",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "license": "AGPL-3",
     "author": "Akretion",
-    "website": "https://github.com/OCA/purchase-workflow",
-    "depends": [
-        "account_payment_partner",
-        # "account_reconciliation_widget",
-    ],
+    "website": "https://github.com/akretion/odoo-factoring",
+    "depends": ["account_payment_partner", "account_payment_mode"],
     "data": [
         "views/account_journal.xml",
         "views/account_journal_dashboard_view.xml",

--- a/account_factoring/models/account_payment.py
+++ b/account_factoring/models/account_payment.py
@@ -1,72 +1,64 @@
 # Copyright (C) 2021 - TODAY Raphaël Valyi - Akretion
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, models
+from odoo import models
 from odoo.tools import float_compare
 
 
 class AccountPayment(models.Model):
     _inherit = "account.payment"
 
-    def _prepare_move_line_default_vals(
-        self, write_off_line_vals=None, force_balance=None
-    ):
+    def _prepare_move_withholding_lines(self, default_values):
+        """Inject factoring fees and holdbacks as withholding lines.
+        Odoo 18 will automatically deduct these from the liquidity line balance.
+        """
+        res = super()._prepare_move_withholding_lines(default_values)
+
+        if not self.journal_id.is_factor or self.payment_type != "inbound":
+            return res
+
         self.ensure_one()
-        line_vals = super()._prepare_move_line_default_vals(
-            write_off_line_vals, force_balance
-        )
-        if self.journal_id.is_factor:
-            if self.payment_type == "inbound":  # credit transfer
-                line_vals = self._simulate_factor_credit_transfer_lines(line_vals)
-            elif self.payment_type == "outbound":  # refund transfer
-                for line in line_vals:
-                    if line["credit"] > 0.0:
-                        line["account_id"] = self.journal_id.default_account_id.id
-        return line_vals
+        dg = self.currency_id.rounding
+        company_currency = self.company_id.currency_id
 
-    def _simulate_factor_credit_transfer_lines(self, line_vals):
-        self.ensure_one()
-        original_liquidity_line = False
-        new_line_vals = []
-        for line in line_vals:
-            account = self.env["account.account"].browse(line["account_id"])
-            # checking the account should avoid taking a write off line:
-            if (
-                account.account_type == "asset_current"
-                and account.internal_group == "asset"
-                and line["debit"] > 0.0
-            ):
-                original_liquidity_line = line
-            else:
-                new_line_vals.append(line)
-
-        if not original_liquidity_line:
-            return line_vals
-
-        amount = original_liquidity_line["debit"]
+        # Logic for amounts calculation
+        amount = self.amount
         factor_fee_amount = self.currency_id.round(
             amount * self.journal_id.factor_fee / 100.0
         )
-        factor_fee_tax_amount = self.currency_id.round(
-            factor_fee_amount * self.journal_id.factor_tax_id.amount / 100.0
-        )
 
+        # Calculate Tax on Fee
+        factor_fee_tax_amount = 0.0
+        fee_tax_account_id = False
+        if self.journal_id.factor_tax_id:
+            factor_fee_tax_amount = self.currency_id.round(
+                factor_fee_amount * self.journal_id.factor_tax_id.amount / 100.0
+            )
+            tax_repartition = (
+                self.journal_id.factor_tax_id.invoice_repartition_line_ids.filtered(
+                    lambda line: line.repartition_type == "tax"
+                )
+            )
+            if tax_repartition:
+                fee_tax_account_id = tax_repartition[0].account_id.id
+
+        # Standard Holdback %
         invoice_holdback = self.currency_id.round(
             amount * self.journal_id.factor_holdback_percent / 100.0
         )
 
-        dg = self.currency_id.rounding
-
+        # Limit Holdback Logic
         initial_balance_journal = self.with_context(
             compute_factor_partner=self.partner_id
         ).journal_id
+
         customer_balance = initial_balance_journal.factor_customer_credit
         initial_holdback = initial_balance_journal.factor_holdback_balance
         initial_limit_holdback = initial_balance_journal.factor_limit_holdback_balance
 
         limit_holdback = self.currency_id.round(
             customer_balance
-            - self.partner_id.factor_credit_limit
+            - (self.partner_id.factor_credit_limit or 0.0)
             - initial_holdback
             - invoice_holdback
             - initial_limit_holdback
@@ -78,137 +70,53 @@ class AccountPayment(models.Model):
             float_compare(limit_holdback, 0.0, precision_rounding=dg) < 0
             or not self.partner_id.factor_credit_limit
         ):
-            limit_holdback = 0
+            limit_holdback = 0.0
 
-        # TODO limit_holdback can also be 0 under other conditions
-        # such as customer_balance < 40% of total factor_balance...
+        # Prepare withholding dictionaries
+        withholding_configs = [
+            (
+                factor_fee_amount,
+                self.journal_id.factor_fee_account_id.id,
+                self.env._("Factor Fee"),
+            ),
+            (factor_fee_tax_amount, fee_tax_account_id, self.env._("Factor Fee Tax")),
+            (
+                invoice_holdback,
+                self.journal_id.factor_holdback_account_id.id,
+                self.env._("Holdback"),
+            ),
+            (
+                limit_holdback,
+                self.journal_id.factor_limit_holdback_account_id.id,
+                self.env._("Limit Holdback"),
+            ),
+        ]
 
-        remaining_amount = self.currency_id.round(
-            original_liquidity_line["debit"]
-            - factor_fee_amount
-            - factor_fee_tax_amount
-            - invoice_holdback
-            - limit_holdback
-        )
+        for amt, acc_id, label in withholding_configs:
+            if float_compare(amt, 0.0, precision_rounding=dg) > 0 and acc_id:
+                res.append(
+                    {
+                        "name": f"{label} - {self.name}",
+                        "account_id": acc_id,
+                        "amount_currency": amt,
+                        "balance": self.currency_id._convert(
+                            amt, company_currency, self.company_id, self.date
+                        ),
+                        "currency_id": self.currency_id.id,
+                        "partner_id": self.partner_id.id,
+                    }
+                )
 
-        liquidity_lines = []
+        return res
 
-        if float_compare(remaining_amount, 0.0, precision_rounding=dg) > 0:
-            liquidity_lines.append(
-                {
-                    "name": f"{_('Factor Credit Transfer')} - "
-                    f"{original_liquidity_line['name']}",
-                    "date_maturity": original_liquidity_line["date_maturity"],
-                    "amount_currency": remaining_amount,
-                    "currency_id": original_liquidity_line["currency_id"],
-                    "debit": remaining_amount,
-                    "credit": 0.0,
-                    "partner_id": original_liquidity_line["partner_id"],
-                    "account_id": self.journal_id.default_account_id.id,
-                }
-            )
-        elif (
-            float_compare(limit_holdback + remaining_amount, 0, precision_rounding=dg)
-            > 0
-        ):
-            # the factor customer balance is such that all money is hold back.
-            # (remaining_amount is negative)
-            # now we should make sure that we don't holdback more than the max possible:
-            limit_holdback += remaining_amount
+    def _prepare_move_liquidity_lines(self, default_values):
+        """Ensure the correct liquidity account is used for factor journals."""
+        res = super()._prepare_move_liquidity_lines(default_values)
 
-        if float_compare(factor_fee_amount, 0.0, precision_rounding=dg) > 0:
-            liquidity_lines.append(
-                {
-                    "name": f"{_('Factor Fee')} - {original_liquidity_line['name']}",
-                    "date_maturity": original_liquidity_line["date_maturity"],
-                    "amount_currency": factor_fee_amount,
-                    "currency_id": original_liquidity_line["currency_id"],
-                    "debit": factor_fee_amount,
-                    "credit": 0.0,
-                    "partner_id": original_liquidity_line["partner_id"],
-                    "account_id": self.journal_id.factor_fee_account_id.id,
-                }
-            )
+        if self.journal_id.is_factor:
+            # For factoring, we often force the use of the default account
+            # instead of outstanding accounts for specific transfer types
+            for line in res:
+                line["account_id"] = self.journal_id.default_account_id.id
 
-        if float_compare(factor_fee_tax_amount, 0.0, precision_rounding=dg) > 0:
-            fee_tax_account = (
-                self.journal_id.factor_tax_id.invoice_repartition_line_ids.filtered(
-                    lambda line: line.repartition_type == "tax"
-                )[0].account_id
-            )
-            liquidity_lines.append(  # TODO fill tax_tag_ids?
-                {
-                    "name": f"{_('Factor Fee Tax')} - "
-                    f"{original_liquidity_line['name']}",
-                    "date_maturity": original_liquidity_line["date_maturity"],
-                    "amount_currency": factor_fee_tax_amount,
-                    "currency_id": original_liquidity_line["currency_id"],
-                    "debit": factor_fee_tax_amount,
-                    "credit": 0.0,
-                    "partner_id": original_liquidity_line["partner_id"],
-                    "account_id": fee_tax_account.id,
-                }
-            )
-
-        if float_compare(invoice_holdback, 0.0, precision_rounding=dg) > 0:
-            liquidity_lines.append(
-                {
-                    "name": f"{self.journal_id.factor_holdback_percent}% "
-                    f"{_('Holdback')} - {original_liquidity_line['name']}",
-                    "date_maturity": original_liquidity_line["date_maturity"],
-                    "amount_currency": invoice_holdback,
-                    "currency_id": original_liquidity_line["currency_id"],
-                    "debit": invoice_holdback,
-                    "credit": 0.0,
-                    "partner_id": original_liquidity_line["partner_id"],
-                    "account_id": self.journal_id.factor_holdback_account_id.id,
-                }
-            )
-
-        if float_compare(limit_holdback, 0.0, precision_rounding=dg) > 0:
-            liquidity_lines.append(
-                {
-                    "name": f"{_('Limit Holdback')} - "
-                    f"{original_liquidity_line['name']}",
-                    "date_maturity": original_liquidity_line["date_maturity"],
-                    "amount_currency": limit_holdback,
-                    "currency_id": original_liquidity_line["currency_id"],
-                    "debit": limit_holdback,
-                    "credit": 0.0,
-                    "partner_id": original_liquidity_line["partner_id"],
-                    "account_id": self.journal_id.factor_limit_holdback_account_id.id,
-                }
-            )
-        return liquidity_lines + new_line_vals
-
-    # def _synchronize_from_moves(self, changed_fields):
-    #     """
-    #     We skip the super move synchronization and do our own here
-    #     """
-    #     if self._context.get("factor_move_synchronization"):
-    #         for pay in self.with_context(skip_account_move_synchronization=True):
-    #             if pay.journal_id.is_factor:
-    #                 pass
-    #                 # TODO implement? see super method
-    #     else:
-    #         # if we did nothing bank statement transfer from
-    #         # factor to bank account would fail
-    #         # because factor accounts are not receivable nor payable.
-    #         context_dict = {}
-    #         factor_accounts = set()
-    #         for journal in self.env["account.journal"].search(
-    #             [("is_factor", "=", True)]
-    #         ):
-    #             factor_accounts.add(journal.default_account_id)
-    #             factor_accounts.add(journal.factor_holdback_account_id)
-    #         for pay in self:
-    #             for line in pay.line_ids:
-    #                 if (
-    #                     line.journal_id.type == "bank"
-    #                     and line.account_id in factor_accounts
-    #                 ):
-    #                     context_dict = {"skip_account_move_synchronization": True}
-    #                     break
-    #         return super(
-    #             AccountPayment, self.with_context(context_dict)
-    #         )._synchronize_from_moves(changed_fields)
+        return res

--- a/account_factoring/models/res_partner.py
+++ b/account_factoring/models/res_partner.py
@@ -7,25 +7,22 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    factor_credit_limit = fields.Monetary("Factor Credit Limit")
+    factor_credit_limit = fields.Monetary()
 
     factor_credit = fields.Monetary(
         compute="_compute_factor_data",
-        string="Factor Credit",
         help="Total amount this customer owes to the factor.",
     )
 
     factor_holdback = fields.Monetary(
-        compute="_compute_factor_data",
-        string="Factor Holdback",
-        help="Total factor holdback amount.",
+        compute="_compute_factor_data", help="Total factor holdback amount."
     )
 
     def _compute_factor_data(self):
         for partner in self:
             journals = (
                 self.env["account.journal"]
-                .with_context({"compute_factor_partner": partner})
+                .with_context(compute_factor_partner=partner)
                 .search([("is_factor", "=", True)])
             )
             partner.factor_credit = sum(journals.mapped("factor_customer_credit"))
@@ -42,8 +39,9 @@ class ResPartner(models.Model):
         for journal in self.env["account.journal"].search([("is_factor", "=", True)]):
             accounts.append(journal.factor_holdback_account_id.id)
             accounts.append(journal.factor_limit_holdback_account_id.id)
-        action["domain"] = (
-            "[('full_reconcile_id', '=', False), ('account_id', 'in', %s), "
-            "('partner_id', '=', %s)]"
-        ) % (accounts, self.id)
+            action["domain"] = (
+                f"[('full_reconcile_id', '=', False), "
+                f"('account_id', 'in', {accounts}), "
+                f"('partner_id', '=', {self.id})]"
+            )
         return action

--- a/account_factoring/tests/test_factoring.py
+++ b/account_factoring/tests/test_factoring.py
@@ -12,42 +12,34 @@ class TestFactorInvoice(AccountTestInvoicingCommon):
         super().setUpClass()
 
         cls.account_account = cls.env["account.account"]
+
         cls.account_factor = cls.account_account.create(
-            dict(
-                code="140000",
-                name="FACTOR",
-                # user_type_id=cls.env.ref(
-                #     "account.data_account_type_current_liabilities"
-                # ).id,
-                account_type="liability_current",
-                internal_group="liability",
-                reconcile=False,
-            )
+            {
+                "code": "140000",
+                "name": "FACTOR",
+                "account_type": "asset_cash",
+                "reconcile": True,
+            }
         )
+
         cls.account_factor_holdback = cls.account_account.create(
-            dict(
-                code="140010",
-                name="FACTOR - holdback",
-                # user_type_id=cls.env.ref(
-                #     "account.data_account_type_current_liabilities"
-                # ).id,
-                account_type="liability_current",
-                internal_group="liability",
-                reconcile=True,
-            )
+            {
+                "code": "140010",
+                "name": "FACTOR - holdback",
+                "account_type": "liability_current",
+                "reconcile": True,
+            }
         )
+
         cls.acc_factor_limit_holdback = cls.account_account.create(
-            dict(
-                code="140020",
-                name="FACTOR - limit holdback",
-                # user_type_id=cls.env.ref(
-                #     "account.data_account_type_current_liabilities"
-                # ).id,
-                account_type="liability_current",
-                internal_group="liability",
-                reconcile=True,
-            )
+            {
+                "code": "140020",
+                "name": "FACTOR - limit holdback",
+                "account_type": "liability_current",
+                "reconcile": True,
+            }
         )
+
         cls.journal_factor = cls.env["account.journal"].create(
             {
                 "name": "FACTOR",
@@ -60,12 +52,14 @@ class TestFactorInvoice(AccountTestInvoicingCommon):
                 "factor_holdback_percent": 10,
             }
         )
+
+        cls.inbound_manual_method = cls.env.ref(
+            "account.account_payment_method_manual_in"
+        )
         cls.payment_mode_factor = cls.env["account.payment.mode"].create(
             {
                 "name": "FACT",
-                "payment_method_id": cls.env.ref(
-                    "account.account_payment_method_manual_in"
-                ).id,
+                "payment_method_id": cls.inbound_manual_method.id,
                 "bank_account_link": "fixed",
                 "fixed_journal_id": cls.journal_factor.id,
             }
@@ -76,10 +70,9 @@ class TestFactorInvoice(AccountTestInvoicingCommon):
             partner=cls.env.ref("base.res_partner_12"),
             products=[cls.product_a],
         )
-
         cls.factor_inv.payment_mode_id = cls.payment_mode_factor
 
-    def initial_balance(self):
+    def test_initial_balance(self):
         self.assertEqual(self.factor_inv.partner_id.factor_credit, 0)
         self.assertEqual(self.factor_inv.partner_id.factor_holdback, 0)
 
@@ -165,6 +158,7 @@ class TestFactorInvoice(AccountTestInvoicingCommon):
         self.factor_inv.partner_id.factor_credit_limit = 800
         self.factor_inv._post()
         self.factor_inv.button_transfer_to_factor()
+
         transfer = self.factor_inv.factor_transfer_id
         self.assertTrue(
             abs(transfer.amount_total - 1000.0 * 1.15) < 0.01


### PR DESCRIPTION
Refactor made on base module account :
https://github.com/odoo/odoo/commit/531b887aec92

Now, the account move lines creation is made easier as all the factor fee, tax and hold-backs are considered "withholding_lines".

----

cc @rvalyi @bealdav : DualSun is still using this module which just crashed because of the last account refactor... so I fixed it and the tests are green !

I merged the fork they made last year for the 18.0 migration : https://github.com/rdualsam/odoo-factoring
But as I don't have the rights to make a PR there, I made it here.

Hope it's OK @rdualsam :sparkles: 